### PR TITLE
release: exceptions@8.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [exceptions@8.0.0-alpha.2](https://github.com/flex-development/exceptions/compare/exceptions@8.0.0-alpha.1...exceptions@8.0.0-alpha.2) (2022-08-29)
+
+
+### :package: Build
+
+* **deps:** remove @types/lodash.isplainobject ([cafbfb7](https://github.com/flex-development/exceptions/commit/cafbfb7e631c5719d070d467af3e9ad0c6706e03))
+* **deps:** remove lodash.isplainobject ([810aca0](https://github.com/flex-development/exceptions/commit/810aca049610fd26ad290cb91c179956c4c5be11))
+* **deps:** replace lodash dependencies with radash ([13a351c](https://github.com/flex-development/exceptions/commit/13a351c5050a1b0d854eee32e3f3fe1e559623b3))
+* **exports:** remove `.d.ts` outputs ([b0b8cbc](https://github.com/flex-development/exceptions/commit/b0b8cbceaab28172123a1425a06a670f65dc9103))
+
+
+### :pencil: Documentation
+
+* built with ([956dd03](https://github.com/flex-development/exceptions/commit/956dd036aa5351908c2ad79cc2d4a711b4194973))
+* **exceptions:** `class Exception<T = any> extends AggregateError<T>` ([6fa084c](https://github.com/flex-development/exceptions/commit/6fa084c75bb9437f46d3166f5e574ad685286994))
+
+
+### :bug: Fixes
+
+* tsconfig path resolution in build files ([6bf6e3d](https://github.com/flex-development/exceptions/commit/6bf6e3d2a834a6b2e2bca7e142694e2c854c1f90))
+* **interfaces:** add `XMLHttpRequest` to `AxiosError#request` definition ([edaa93f](https://github.com/flex-development/exceptions/commit/edaa93f6b822d5dcccd5a3a7ee0166be1911329c))
+
 ## [exceptions@8.0.0-alpha.1](https://github.com/flex-development/exceptions/compare/exceptions@7.0.1...exceptions@8.0.0-alpha.1) (2022-08-28)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/exceptions",
   "description": "Custom error handling",
-  "version": "8.0.0-alpha.1",
+  "version": "8.0.0-alpha.2",
   "keywords": [
     "error-handling",
     "exceptions",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `8.0.0-alpha.2`
- added `CHANGELOG` entry for `8.0.0-alpha.2`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.22.1
      Coverage enabled with c8

 ✓ src/guards/__tests__/is-exception-code.spec.ts > exceptions/unit:guards/isExceptionCode > should return false given ["I_AM_A_TEAPOT"]
 ✓ src/guards/__tests__/is-exception-code.spec.ts > exceptions/unit:guards/isExceptionCode > should return true given [413]
 ✓ src/guards/__tests__/is-exception-id.spec.ts > exceptions/unit:guards/isExceptionId > should return false given [401]
 ✓ src/guards/__tests__/is-exception-id.spec.ts > exceptions/unit:guards/isExceptionId > should return true given ["GATEWAY_TIMEOUT"]
 ✓ src/guards/__tests__/is-exception-class-name.spec.ts > exceptions/unit:guards/isExceptionClassName > should return false given ["TOO_MANY_REQUESTS"]
 ✓ src/guards/__tests__/is-exception-class-name.spec.ts > exceptions/unit:guards/isExceptionClassName > should return true given ["uri-too-long"]
 ✓ src/guards/__tests__/is-exception-json.spec.ts > exceptions/unit:guards/isExceptionJSON > should return false if value is not ExceptionJSON
 ✓ src/guards/__tests__/is-exception-json.spec.ts > exceptions/unit:guards/isExceptionJSON > should return true if value is ExceptionJSON
 ✓ src/exceptions/__tests__/validation.exception.spec.ts > exceptions/unit:exceptions/ValidationException > constructor > should construct ValidationException with defaults
 ✓ src/exceptions/__tests__/validation.exception.spec.ts > exceptions/unit:exceptions/ValidationException > constructor > should construct ValidationException with overrides
 ✓ src/guards/__tests__/is-exception.spec.ts > exceptions/unit:guards/isException > should return false if value is not Exception
 ✓ src/guards/__tests__/is-exception.spec.ts > exceptions/unit:guards/isException > should return true if value is Exception
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #data > should omit dto.data.errors and dto.data.message
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #data > should use dto.data properties if dto.data is ExceptionJSON
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #errors > should equal [[Error]] given [undefined, undefined, {"errors": [[Error]]}]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #errors > should equal [[Error]] given [undefined, undefined, {"errors": [Error]}]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #message > should equal "Unknown error" given [undefined, "Unknown error", {}]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #message > should equal "" given [undefined, "", {"message": ""}]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > constructor > #name > should equal "Exception"
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "INTERNAL_SERVER_ERROR" given [-1]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "BAD_REQUEST" given [400]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "UNAUTHORIZED" given [401]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "PAYMENT_REQUIRED" given [402]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "FORBIDDEN" given [403]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "NOT_FOUND" given [404]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "METHOD_NOT_ALLOWED" given [405]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "NOT_ACCEPTABLE" given [406]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "PROXY_AUTHENTICATION_REQUIRED" given [407]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "REQUEST_TIMEOUT" given [408]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "CONFLICT" given [409]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "GONE" given [410]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "LENGTH_REQUIRED" given [411]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "PRECONDITION_FAILED" given [412]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "PAYLOAD_TOO_LARGE" given [413]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "URI_TOO_LONG" given [414]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "UNSUPPORTED_MEDIA_TYPE" given [415]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "REQUESTED_RANGE_NOT_SATISFIABLE" given [416]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "EXPECTATION_FAILED" given [417]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "I_AM_A_TEAPOT" given [418]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "MISDIRECTED" given [421]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "UNPROCESSABLE_ENTITY" given [422]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "FAILED_DEPENDENCY" given [424]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "TOO_MANY_REQUESTS" given [429]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "INTERNAL_SERVER_ERROR" given [500]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "NOT_IMPLEMENTED" given [501]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "BAD_GATEWAY" given [502]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "SERVICE_UNAVAILABLE" given [503]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "GATEWAY_TIMEOUT" given [504]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .findIdByCode > should return "HTTP_VERSION_NOT_SUPPORTED" given [505]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 500 given [-1]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 400 given [400]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 401 given [401]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 402 given [402]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 403 given [403]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 404 given [404]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 405 given [405]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 406 given [406]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 407 given [407]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 408 given [408]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 409 given [409]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 410 given [410]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 411 given [411]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 412 given [412]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 413 given [413]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 414 given [414]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 415 given [415]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 416 given [416]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 417 given [417]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 418 given [418]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 421 given [421]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 422 given [422]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 424 given [424]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 429 given [429]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 500 given [500]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 501 given [501]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 502 given [502]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 503 given [503]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 504 given [504]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .formatCode > should return 505 given [505]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromAxiosError > should return Exception given [[Error: Request failed with status code 404]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromAxiosError > should return Exception given [[Error: Request failed with status code 500]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromFirebaseError > should return Exception given [[Error: Test Firebase error with invalid code]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromFirebaseError > should return Exception given [[Error: Test Firebase error message with valid code]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromNextError > should return Exception given [[Error: Test Next.js error with statusCode]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > .fromNextError > should return Exception given [[Error: Test Next.js error without statusCode]]
 ✓ src/exceptions/__tests__/base.exception.spec.ts > exceptions/unit:exceptions/Exception > #toJSON > should return json representation of Exception

Test Files  7 passed (7)
     Tests  86 passed (86)
  Start at  15:05:59
  Duration  2.71s (transform 253ms, setup 3.15s, collect 1.11s, tests 91ms)

 % Coverage report from c8
--------------------------------|---------|----------|---------|---------|-------------------------
File                            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s       
--------------------------------|---------|----------|---------|---------|-------------------------
All files                       |   96.44 |    85.08 |     100 |   96.44 |                         
 config                         |     100 |      100 |     100 |     100 |                         
  constants.ts                  |     100 |      100 |     100 |     100 |                         
 enums                          |     100 |      100 |     100 |     100 |                         
  exception-class-name.ts       |     100 |      100 |     100 |     100 |                         
  exception-code.ts             |     100 |      100 |     100 |     100 |                         
  exception-id.ts               |     100 |      100 |     100 |     100 |                         
  firebase-error-code.ts        |     100 |      100 |     100 |     100 |                         
  firebase-error-status-code.ts |     100 |      100 |     100 |     100 |                         
 exceptions                     |   91.95 |    82.82 |     100 |   91.95 |                         
  base.exception.ts             |   89.96 |    80.23 |     100 |   89.96 | 183-184,186-199,232-247 
  validation.exception.ts       |     100 |      100 |     100 |     100 |                         
 guards                         |     100 |      100 |     100 |     100 |                         
  is-exception-class-name.ts    |     100 |      100 |     100 |     100 |                         
  is-exception-code.ts          |     100 |      100 |     100 |     100 |                         
  is-exception-id.ts            |     100 |      100 |     100 |     100 |                         
  is-exception-json.ts          |     100 |      100 |     100 |     100 |                         
  is-exception.ts               |     100 |      100 |     100 |     100 |                         
--------------------------------|---------|----------|---------|---------|-------------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/exceptions                                                             15:07:59
✔ Build succeeded for exceptions                                                                    15:08:02
  dist (total size: 76.2 kB)                                                                        15:08:02
  └─ dist/config/constants.d.cts (181 B)
  └─ dist/dtos/index.d.cts (230 B)
  └─ dist/enums/exception-class-name.cjs (2.11 kB)
  └─ dist/exceptions/base.exception.d.cts (4.22 kB)
  └─ dist/guards/index.d.cts (400 B)
  └─ dist/interfaces/axios-error-json.d.cts (781 B)
  └─ dist/index.d.cts (255 B)
  └─ dist/dtos/index.cjs (13 B)
  └─ dist/dtos/validation-exception.cjs (13 B)
  └─ dist/config/constants.cjs (149 B)
  └─ dist/dtos/exception-data.cjs (13 B)
  └─ dist/enums/exception-code.d.cts (1.04 kB)
  └─ dist/enums/exception-code.cjs (2.62 kB)
  └─ dist/types/exception-data.d.cts (220 B)
  └─ dist/enums/exception-id.d.cts (1.46 kB)
  └─ dist/dtos/exception-data.d.cts (576 B)
  └─ dist/enums/firebase-error-code.cjs (8.52 kB)
  └─ dist/enums/firebase-error-status-code.d.cts (4.09 kB)
  └─ dist/index.cjs (2.5 kB)
  └─ dist/enums/exception-class-name.d.cts (1.45 kB)
  └─ dist/enums/exception-id.cjs (1.91 kB)
  └─ dist/enums/index.d.cts (408 B)
  └─ dist/exceptions/index.cjs (1.09 kB)
  └─ dist/enums/index.cjs (1.31 kB)
  └─ dist/exceptions/base.exception.cjs (3.56 kB)
  └─ dist/guards/index.cjs (1.28 kB)
  └─ dist/enums/firebase-error-status-code.cjs (16.8 kB)
  └─ dist/guards/is-exception-code.cjs (575 B)
  └─ dist/exceptions/index.d.cts (242 B)
  └─ dist/guards/is-exception-class-name.cjs (601 B)
  └─ dist/guards/is-exception-class-name.d.cts (398 B)
  └─ dist/exceptions/validation.exception.d.cts (1.63 kB)
  └─ dist/guards/is-exception-json.d.cts (379 B)
  └─ dist/dtos/validation-exception.d.cts (656 B)
  └─ dist/guards/is-exception.d.cts (365 B)
  └─ dist/exceptions/validation.exception.cjs (1.14 kB)
  └─ dist/interfaces/exception-json.d.cts (808 B)
  └─ dist/guards/is-exception-id.d.cts (349 B)
  └─ dist/guards/is-exception-code.d.cts (363 B)
  └─ dist/interfaces/exception-json.cjs (13 B)
  └─ dist/interfaces/axios-error.cjs (13 B)
  └─ dist/interfaces/firebase-error.d.cts (1.54 kB)
  └─ dist/guards/is-exception.cjs (271 B)
  └─ dist/interfaces/axios-error.d.cts (869 B)
  └─ dist/enums/firebase-error-code.d.cts (6.22 kB)
  └─ dist/interfaces/index.d.cts (394 B)
  └─ dist/interfaces/next-error.d.cts (404 B)
  └─ dist/interfaces/next-error.cjs (13 B)
  └─ dist/types/index.cjs (13 B)
  └─ dist/types/validation-exception-errors.d.cts (408 B)
  └─ dist/interfaces/axios-error-json.cjs (13 B)
  └─ dist/types/exception-errors.cjs (13 B)
  └─ dist/types/index.d.cts (289 B)
  └─ dist/types/validation-exception-errors.cjs (13 B)
  └─ dist/guards/is-exception-json.cjs (258 B)
  └─ dist/interfaces/index.cjs (13 B)
  └─ dist/types/exception-errors.d.cts (268 B)
  └─ dist/types/exception-data.cjs (13 B)
  └─ dist/interfaces/firebase-error.cjs (13 B)
  └─ dist/guards/is-exception-id.cjs (445 B)
  dist (total size: 67.2 kB)                                                                        15:08:02
  └─ dist/index.mjs (260 B)
  └─ dist/dtos/index.mjs
  └─ dist/dtos/exception-data.d.mts (576 B)
  └─ dist/dtos/validation-exception.mjs
  └─ dist/dtos/index.d.mts (230 B)
  └─ dist/enums/exception-class-name.d.mts (1.45 kB)
  └─ dist/config/constants.d.mts (181 B)
  └─ dist/enums/exception-class-name.mjs (1.98 kB)
  └─ dist/dtos/exception-data.mjs
  └─ dist/enums/exception-code.mjs (2.49 kB)
  └─ dist/index.d.mts (255 B)
  └─ dist/enums/exception-id.mjs (1.78 kB)
  └─ dist/config/constants.mjs (36 B)
  └─ dist/enums/firebase-error-code.d.mts (6.22 kB)
  └─ dist/enums/firebase-error-code.mjs (8.39 kB)
  └─ dist/enums/firebase-error-status-code.d.mts (4.09 kB)
  └─ dist/exceptions/base.exception.d.mts (4.22 kB)
  └─ dist/enums/index.d.mts (408 B)
  └─ dist/exceptions/index.d.mts (242 B)
  └─ dist/enums/firebase-error-status-code.mjs (15.5 kB)
  └─ dist/exceptions/base.exception.mjs (3.13 kB)
  └─ dist/enums/index.mjs (363 B)
  └─ dist/enums/exception-code.d.mts (1.04 kB)
  └─ dist/enums/exception-id.d.mts (1.46 kB)
  └─ dist/guards/index.d.mts (400 B)
  └─ dist/exceptions/validation.exception.d.mts (1.63 kB)
  └─ dist/guards/index.mjs (348 B)
  └─ dist/exceptions/index.mjs (179 B)
  └─ dist/guards/is-exception-id.d.mts (349 B)
  └─ dist/dtos/validation-exception.d.mts (656 B)
  └─ dist/guards/is-exception-code.d.mts (363 B)
  └─ dist/interfaces/axios-error-json.mjs
  └─ dist/guards/is-exception.d.mts (365 B)
  └─ dist/guards/is-exception-class-name.mjs (297 B)
  └─ dist/guards/is-exception-class-name.d.mts (398 B)
  └─ dist/guards/is-exception.mjs (138 B)
  └─ dist/guards/is-exception-code.mjs (271 B)
  └─ dist/guards/is-exception-id.mjs (177 B)
  └─ dist/interfaces/axios-error.mjs
  └─ dist/interfaces/axios-error-json.d.mts (781 B)
  └─ dist/guards/is-exception-json.d.mts (379 B)
  └─ dist/interfaces/firebase-error.mjs
  └─ dist/exceptions/validation.exception.mjs (835 B)
  └─ dist/interfaces/exception-json.d.mts (808 B)
  └─ dist/interfaces/index.d.mts (394 B)
  └─ dist/interfaces/next-error.d.mts (404 B)
  └─ dist/guards/is-exception-json.mjs (125 B)
  └─ dist/types/exception-errors.mjs
  └─ dist/interfaces/next-error.mjs
  └─ dist/types/exception-data.d.mts (220 B)
  └─ dist/interfaces/exception-json.mjs
  └─ dist/types/exception-data.mjs
  └─ dist/interfaces/index.mjs
  └─ dist/interfaces/axios-error.d.mts (869 B)
  └─ dist/types/index.mjs
  └─ dist/interfaces/firebase-error.d.mts (1.54 kB)
  └─ dist/types/validation-exception-errors.mjs
  └─ dist/types/validation-exception-errors.d.mts (408 B)
  └─ dist/types/index.d.mts (289 B)
  └─ dist/types/exception-errors.d.mts (268 B)
Σ Total dist size (byte size): 143 kB
                                                                                                    15:08:02
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] [pr naming conventions][1]
- [x] project was run locally to verify that there are no errors
- [x] documentation added or updated

[1]: https://github.com/flex-development/exceptions/blob/main/CONTRIBUTING.md#pull-request-titles
